### PR TITLE
#7 fix

### DIFF
--- a/Assets/_Scenes/MainScene.unity
+++ b/Assets/_Scenes/MainScene.unity
@@ -2387,7 +2387,7 @@ GameObject:
   - component: {fileID: 809811451}
   - component: {fileID: 809811453}
   m_Layer: 0
-  m_Name: GameServerManager
+  m_Name: ServerManager
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0


### PR DESCRIPTION
### 📌 문제 원인
- PlayerController.cs의 `Update()`에서 서버가 매 프레임 NavMeshAgent의 목적지를 반복적으로 설정함.
- 게임서버에서 이동 명령이 연속으로 들어오는 상황이 아니라도, 불필요하게 SetDestination이 호출되어 성능 저하 및 이동 버그 발생.

### 📌 개선 사항 (NetworkVariable 기반 이벤트 처리 적용)

1. **OnNetworkSpawn**
   - 서버 측 `Update()`에서 처리하던 이동 로직 제거.
   - `_networkDestination` NetworkVariable의 `OnValueChanged` 이벤트에  
     `OnDestinationChanged` 콜백을 등록하여, 목적지가 바뀔 때만 이동 처리.

2. **OnNetworkDespawn**
   - 메모리 누수를 방지하기 위해  
     `_networkDestination.OnValueChanged -= OnDestinationChanged` 구독 해제.

3. **Update**
   - 서버 이동 처리 로직 완전히 제거.
   - 클라이언트 입력 처리만 남김.

4. **OnDestinationChanged (신규 메서드)**
   - `_networkDestination` 값이 변경될 때 호출.
   - **서버에서만** `agent.SetDestination()`을 실행하여 실제 이동 위치를 갱신.
   - 목적지가 변경될 때만 NavMeshAgent가 갱신되므로 불필요한 호출 제거.

5. **HandleServerMovement 제거**
   - NetworkVariable 기반 이벤트 처리로 대체되어 더 이상 필요 없음.

### 📌 결과
- 서버에서 매 프레임 불필요하게 SetDestination을 호출하던 문제 해결.
- 이동 명령이 실제로 변경될 때만 NavMeshAgent가 갱신되므로 안정성과 성능 모두 개선됨.