### PR TITLE
#41 bug

### DIFF
--- a/Assets/Settings/Build Profiles.meta
+++ b/Assets/Settings/Build Profiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 088fd22ac42f24e28b6af2fb748cf16a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Prefabs/GameObject/Enemy.prefab
+++ b/Assets/_Prefabs/GameObject/Enemy.prefab
@@ -34,7 +34,7 @@ Transform:
   m_GameObject: {fileID: 4780730189820231958}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 939.3509, y: 0, z: 1566.3025}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -132,7 +132,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Unity.Netcode.Runtime::Unity.Netcode.NetworkObject
-  GlobalObjectIdHash: 2808268810
+  GlobalObjectIdHash: 639909936
   InScenePlacedSourceGlobalObjectIdHash: 0
   DeferredDespawnTick: 0
   Ownership: 1
@@ -161,6 +161,12 @@ MonoBehaviour:
   EnemyWorldSpaceUIPrefab: {fileID: 1294471187131378791, guid: 32fe49cb62525b8408026c11e19d9764, type: 3}
   enemyStats: {fileID: 1552223133592830171}
   attackInterval: 2
+  chaseRange: 5
+  patrolStoppingDistance: 0.5
+  patrolRadius: 5
+  returnHomeDistance: 10
+  patrolWaitTime: 2
+  respawnDelay: 5
 --- !u!114 &1552223133592830171
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_Scripts/Combat/AttackHandler.cs
+++ b/Assets/_Scripts/Combat/AttackHandler.cs
@@ -8,6 +8,8 @@ public class AttackHandler : NetworkBehaviour, IAttacker
     [SerializeField] private float attackRange;
     [SerializeField] private int attackDamage;
 
+    public float AttackRange => attackRange;
+
     private ICharacterStats _characterStats;
 
     private void Awake()

--- a/Assets/_Scripts/Combat/IAttacker.cs
+++ b/Assets/_Scripts/Combat/IAttacker.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 /// </summary>
 public interface IAttacker
 {
+    float AttackRange { get; }
 
     void PerformAttack(NetworkObjectReference targetNetworkObjectRef);
     

--- a/Assets/_Scripts/Networking/GameNetworkManager.cs
+++ b/Assets/_Scripts/Networking/GameNetworkManager.cs
@@ -67,7 +67,7 @@ public class GameNetworkManager : MonoBehaviour
         {
             if (enemyPrefab != null)
             {
-                GameObject enemyInstance = Instantiate(enemyPrefab, new Vector3(0, 2, 0), Quaternion.identity);
+                GameObject enemyInstance = Instantiate(enemyPrefab, new Vector3(0, 0, 0), Quaternion.identity);
                 NetworkObject enemyNetworkObject = enemyInstance.GetComponent<NetworkObject>();
                 if (enemyNetworkObject != null)
                 {
@@ -305,6 +305,32 @@ public class GameNetworkManager : MonoBehaviour
     {
         clientInfo = null;
         return connectedClientsData.TryGetValue(clientId, out clientInfo);
+    }
+
+    public void RespawnEnemy(NetworkObject enemyNetworkObject, float delay)
+    {
+        StartCoroutine(RespawnEnemyCoroutine(enemyNetworkObject, delay));
+    }
+
+    private System.Collections.IEnumerator RespawnEnemyCoroutine(NetworkObject enemyNetworkObject, float delay)
+    {
+        yield return new WaitForSeconds(delay);
+
+        if (enemyNetworkObject != null && enemyNetworkObject.IsSpawned)
+        {
+            if (enemyNetworkObject.TryGetComponent<Enemy>(out Enemy enemy))
+            {
+                enemy.Respawn();
+            }
+            else
+            {
+                Debug.LogError($"[GNM] Could not find Enemy component on NetworkObject to respawn.");
+            }
+        }
+        else
+        {
+            Debug.LogWarning($"[GNM] Tried to respawn an enemy that no longer exists or is not spawned.");
+        }
     }
     
     // ============================================

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,6 +5,7 @@
     "com.unity.cinemachine": "2.10.5",
     "com.unity.collab-proxy": "2.10.2",
     "com.unity.collections": "2.6.2",
+    "com.unity.dedicated-server": "2.0.1",
     "com.unity.ext.nunit": "2.0.5",
     "com.unity.ide.rider": "3.0.38",
     "com.unity.ide.visualstudio": "2.0.25",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -48,6 +48,13 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.dedicated-server": {
+      "version": "2.0.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.ext.nunit": {
       "version": "2.0.5",
       "depth": 0,

--- a/ProjectSettings/MultiplayerManager.asset
+++ b/ProjectSettings/MultiplayerManager.asset
@@ -3,5 +3,9 @@
 --- !u!655991488 &1
 MultiplayerManager:
   m_ObjectHideFlags: 0
-  m_EnableMultiplayerRoles: 0
-  m_StrippingTypes: {}
+  m_EnableMultiplayerRoles: 1
+  m_EnablePlayModeLocalDeployment: 0
+  m_EnablePlayModeRemoteDeployment: 0
+  m_StrippingTypes:
+    1: []
+    2: []

--- a/ProjectSettings/Packages/com.unity.dedicated-server/ContentSelectionSettings.asset
+++ b/ProjectSettings/Packages/com.unity.dedicated-server/ContentSelectionSettings.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 53
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d3c63bcbf0c7c4315b6f985026440942, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.DedicatedServer.MultiplayerRoles.Editor::Unity.Multiplayer.Editor.ContentSelectionSettings
+  m_EnableSafetyChecks: 1
+  m_AutomaticSelectionOptions:
+    m_StripRenderComponents: 0
+    m_StripUIComponents: 0
+    m_StripAudioComponents: 0
+    m_CustomComponentsList:
+      m_Keys: []
+      m_Values: 


### PR DESCRIPTION
  ### 1. Enemy.cs
  >AI 상태 머신(State Machine)과 관련된 로직 개선
 * 초기 순찰 버그 수정
     * Idle 상태를 도입하여, 스폰 직후(OnNetworkSpawn)나 리스폰 시(HandleEnemyRespawned) Idle 상태를 거쳐 Patrol 상태로 안전하게 전환되도록 변경
     * Update() 문에 Idle 상태일 때 TransitionToPatrol() 코루틴을 호출하여 순찰을 시작하는 로직을 추가
     * AI기능 관련 변수 미세 조정

 * 리스폰 로직 변경
     * 사망 시(HandleEnemyDied) 자체적으로 리스폰 코루틴을 호출하는 대신, GameNetworkManager의 새로운 리스폰 함수를 호출하도록 변경
     * Respawn() 함수는 스탯과 상태를 초기화하는 역할만 하도록 단순화

  ### 2. GameNetworkManager.cs
  >Enemy의 리스폰(리스폰)을 관리하는 새로운 중앙 집중식 로직이 추가

   * Enemy 리스폰 함수 추가
       * Enemy가 죽으면 GameNetworkManager가 지정된 시간(delay) 후에 해당 Enemy의 Respawn() 함수를 호출하여 부활시키는 과정을 통해 적이 죽은 후 리스폰되지 않던 버그 해결