### PR TITLE
#48 refactor

### DIFF
--- a/Assets/_Scripts/GameObject/Actor/EnemyCharactor/EnemyCharacter.cs
+++ b/Assets/_Scripts/GameObject/Actor/EnemyCharactor/EnemyCharacter.cs
@@ -92,7 +92,7 @@ public class EnemyCharacter : NetworkBehaviour,
     }
     public void AddModifier(StatModifier m) { throw new NotImplementedException(); }
     public void RemoveModifier(Guid id) { throw new NotImplementedException(); }
-
+    
     // IAttackHandler
     public bool CanNormalAttack() => true;
     public void NormalAttack(AttackContext ctx)
@@ -111,145 +111,254 @@ public class EnemyCharacter : NetworkBehaviour,
     public AttackType GetAttackType() => AttackType.Melee;
     public DamageType GetDefaultDamageType() => DamageType.Physical;
 
-    // ISpawnable
-    public void OnSpawn(ISpawnContext ctx)
-    {
-        _agent.enabled = IsServer;
+        // ISpawnable
 
-        _currentHealth.OnValueChanged += OnHealthUpdated;
-        OnHealthUpdated(0, _currentHealth.Value);
-        
-        if (ctx != null && ctx.Point != null)
+        public void OnSpawn(ISpawnContext ctx)
+
         {
-            transform.position = ctx.Point.GetPosition();
-            transform.rotation = ctx.Point.GetRotation();
-        }
 
-        _agent.stoppingDistance = patrolStoppingDistance;
-        
-        if (IsServer)
-        {
-            AIManager.Instance.RegisterAI(
-                this, 
-                _agent, 
-                transform, 
-                transform.position,
-                transform.rotation,
-                attackInterval,
-                chaseRange,
-                patrolStoppingDistance,
-                patrolRadius,
-                returnHomeDistance,
-                patrolWaitTime
-            );
-        }
-    }
-    
-    public IRespawnPolicy GetRespawnPolicy() => new EnemyRespawnPolicy(this);
+            _agent.enabled = IsServer;
 
+            
 
-    // IMovable
-    public void Move(Vector3 direction, float deltaTime) { if(_agent.enabled) _agent.Move(direction * deltaTime); }
-    public void Teleport(Vector3 pos)
-    {
-        if (_agent.enabled) _agent.Warp(pos);
-        else transform.position = pos;
-    }
+            if (ctx != null && ctx.Point != null)
 
-    // IAnimPlayable
-    public void Play(string state) { /* TODO: Connect to Animator */ }
-    public void CrossFade(string state, float duration) { /* TODO: Connect to Animator */ }
-
-    // ISaveable
-    public SaveData SerializeForSave() { throw new NotImplementedException(); }
-    public void DeserializeFromSave(SaveData data) { throw new NotImplementedException(); }
-    #endregion
-
-    #region Nested Classes (Health, Respawn Policy)
-    private class EnemyHealth : IHealth
-    {
-        private readonly EnemyCharacter _owner;
-        public float Current => _owner.GetStat(StatType.Health);
-        public float Max => _owner.GetStat(StatType.MaxHealth);
-
-        public event Action<DamageEvent> OnDamaged;
-        public event Action OnDied;
-
-        public EnemyHealth(EnemyCharacter owner)
-        {
-            _owner = owner;
-            _owner._currentHealth.OnValueChanged += (prev, curr) =>
             {
-                if (curr < prev)
-                    OnDamaged?.Invoke(new DamageEvent { Amount = prev - curr });
-                if (curr <= 0 && prev > 0)
-                    OnDied?.Invoke();
-            };
+
+                transform.position = ctx.Point.GetPosition();
+
+                transform.rotation = ctx.Point.GetRotation();
+
+            }
+
+    
+
+            _agent.stoppingDistance = patrolStoppingDistance;
+
+            
+
+            if (IsServer)
+
+            {
+
+                AIManager.Instance.RegisterAI(
+
+                    this, 
+
+                    _agent, 
+
+                    transform, 
+
+                    transform.position,
+
+                    transform.rotation,
+
+                    attackInterval,
+
+                    chaseRange,
+
+                    patrolStoppingDistance,
+
+                    patrolRadius,
+
+                    returnHomeDistance,
+
+                    patrolWaitTime
+
+                );
+
+            }
+
         }
 
-        public void ApplyDamage(DamageEvent evt)
-        {
-            if (!_owner.IsServer) return;
-            var newHealth = Current - evt.Amount;
-            _owner.SetStat(StatType.Health, newHealth);
-        }
-
-        public void Heal(float amount)
-        {
-            if (!_owner.IsServer) return;
-            var newHealth = Current + amount;
-            _owner.SetStat(StatType.Health, newHealth);
-        }
-    }
-
-    private class EnemyRespawnPolicy : IRespawnPolicy
-    {
-        private readonly EnemyCharacter _owner;
-        public EnemyRespawnPolicy(EnemyCharacter owner) { _owner = owner; }
-        public bool ShouldRespawn(ISpawnable target) => true;
-        public TimeSpan GetRespawnDelay(ISpawnable target) => TimeSpan.FromSeconds(_owner.respawnDelay);
-        public ISpawnPoint SelectRespawnPoint(ISpawnable target)
-        {
-            return null;
-        }
-    }
-
-#endregion
-
-    private void Awake()
-    {
-        _agent = GetComponent<NavMeshAgent>();
-        _enemyHealth = new EnemyHealth(this);
         
-        _statProvider = this;
-        _attackHandler = this;
-    }
 
-    public override void OnNetworkSpawn()
-    {
-        base.OnNetworkSpawn();
-    }
+        public IRespawnPolicy GetRespawnPolicy() => new EnemyRespawnPolicy(this);
 
-    public override void OnNetworkDespawn()
-    {
-        base.OnNetworkDespawn();
-        _currentHealth.OnValueChanged -= OnHealthUpdated;
+    
 
-        if (IsServer)
+    
+
+        // IMovable
+
+        public void Move(Vector3 direction, float deltaTime) { if(_agent.enabled) _agent.Move(direction * deltaTime); }
+
+        public void Teleport(Vector3 pos)
+
         {
-            AIManager.Instance.UnregisterAI(this);
+
+            if (_agent.enabled) _agent.Warp(pos);
+
+            else transform.position = pos;
+
         }
+
+    
+
+        // IAnimPlayable
+
+        public void Play(string state) { /* TODO: Connect to Animator */ }
+
+        public void CrossFade(string state, float duration) { /* TODO: Connect to Animator */ }
+
+    
+
+        // ISaveable
+
+        public SaveData SerializeForSave() { throw new NotImplementedException(); }
+
+        public void DeserializeFromSave(SaveData data) { throw new NotImplementedException(); }
+
+        #endregion
+
+    
+
+        #region Nested Classes (Health, Respawn Policy)
+
+        private class EnemyHealth : IHealth
+
+        {
+
+            private readonly EnemyCharacter _owner;
+
+            public float Current => _owner.GetStat(StatType.Health);
+
+            public float Max => _owner.GetStat(StatType.MaxHealth);
+
+    
+
+            public event Action<DamageEvent> OnDamaged;
+
+            public event Action OnDied;
+
+    
+
+            public EnemyHealth(EnemyCharacter owner)
+
+            {
+
+                _owner = owner;
+
+                _owner._currentHealth.OnValueChanged += (prev, curr) =>
+
+                {
+
+                    if (curr < prev)
+
+                        OnDamaged?.Invoke(new DamageEvent { Amount = prev - curr });
+
+                    if (curr <= 0 && prev > 0)
+
+                        OnDied?.Invoke();
+
+                };
+
+            }
+
+    
+
+            public void ApplyDamage(DamageEvent evt)
+
+            {
+
+                if (!_owner.IsServer) return;
+
+                var newHealth = Current - evt.Amount;
+
+                _owner.SetStat(StatType.Health, newHealth);
+
+            }
+
+    
+
+            public void Heal(float amount)
+
+            {
+
+                if (!_owner.IsServer) return;
+
+                var newHealth = Current + amount;
+
+                _owner.SetStat(StatType.Health, newHealth);
+
+            }
+
+        }
+
+    
+
+        private class EnemyRespawnPolicy : IRespawnPolicy
+
+        {
+
+            private readonly EnemyCharacter _owner;
+
+            public EnemyRespawnPolicy(EnemyCharacter owner) { _owner = owner; }
+
+            public bool ShouldRespawn(ISpawnable target) => true;
+
+            public TimeSpan GetRespawnDelay(ISpawnable target) => TimeSpan.FromSeconds(_owner.respawnDelay);
+
+            public ISpawnPoint SelectRespawnPoint(ISpawnable target)
+
+            {
+
+                return null;
+
+            }
+
+        }
+
+        #endregion
+
+    
+
+        private void Awake()
+
+        {
+
+            _agent = GetComponent<NavMeshAgent>();
+
+            _enemyHealth = new EnemyHealth(this);
+
+            
+
+            _statProvider = this;
+
+            _attackHandler = this;
+
+        }
+
+    
+
+        public override void OnNetworkSpawn()
+
+        {
+
+            base.OnNetworkSpawn();
+
+        }
+
+    
+
+        public override void OnNetworkDespawn()
+
+        {
+
+            base.OnNetworkDespawn();
+
+    
+
+            if (IsServer)
+
+            {
+
+                AIManager.Instance.UnregisterAI(this);
+
+            }
+
+        }
+
     }
 
-    private void OnHealthUpdated(float previousValue, float newValue)
-    {
-        bool isDead = newValue <= 0;
-        
-        if (TryGetComponent<Collider>(out var col)) col.enabled = !isDead;
-        
-        if(IsServer && isDead)
-        {
-            AIManager.Instance.SetEnemyDead(this);
-        }
-    }
-}
+    

--- a/Assets/_Scripts/Manager/AIManager.cs
+++ b/Assets/_Scripts/Manager/AIManager.cs
@@ -277,16 +277,56 @@ public class AIManager : NetworkBehaviour
         }
     }
 
-    public void SetEnemyDead(ICombatant enemyCombatant)
-    {
-        if (!IsServer) return;
+        public void SetEnemyDead(ICombatant enemyCombatant)
 
-        if (_enemyAIDataMap.TryGetValue(enemyCombatant, out EnemyAIData aiData))
         {
-            if (aiData.Combatant.GetHealth().Current <= 0 && aiData.CurrentState != EnemyAIState.Dead)
+
+            if (!IsServer) return;
+
+    
+
+            if (_enemyAIDataMap.TryGetValue(enemyCombatant, out EnemyAIData aiData))
+
             {
-                SetAIState(aiData, EnemyAIState.Dead);
+
+                if (aiData.Combatant.GetHealth().Current <= 0 && aiData.CurrentState != EnemyAIState.Dead)
+
+                {
+
+                    SetAIState(aiData, EnemyAIState.Dead);
+
+                }
+
             }
+
         }
+
+    
+
+        public void SetEnemyAlive(ICombatant enemyCombatant)
+
+        {
+
+            if (!IsServer) return;
+
+    
+
+            if (_enemyAIDataMap.TryGetValue(enemyCombatant, out EnemyAIData aiData))
+
+            {
+
+                if (aiData.CurrentState == EnemyAIState.Dead)
+
+                {
+
+                    SetAIState(aiData, EnemyAIState.Idle);
+
+                }
+
+            }
+
+        }
+
     }
-}
+
+    

--- a/Assets/_Scripts/Manager/SpawnManager.cs
+++ b/Assets/_Scripts/Manager/SpawnManager.cs
@@ -4,6 +4,7 @@ using Jae.Common;
 using System.Collections.Generic;
 using System.Collections;
 using System;
+using UnityEngine.AI;
 
 public class SpawnManager : NetworkBehaviour
 {
@@ -12,7 +13,7 @@ public class SpawnManager : NetworkBehaviour
     [Header("Player Spawn Settings")]
     [SerializeField] private GameObject playerPrefab;
     [SerializeField] private Transform[] playerSpawnPoints;
-    
+
     [System.Serializable]
     public struct EnemySpawnInfo
     {
@@ -24,6 +25,8 @@ public class SpawnManager : NetworkBehaviour
     [SerializeField] private List<EnemySpawnInfo> enemySpawnList;
 
     private bool _initialEnemiesSpawned = false;
+    private Dictionary<ICombatant, Vector3> _initialPositions = new Dictionary<ICombatant, Vector3>();
+
 
     // Concrete implementation of ISpawnContext
     public class DefaultSpawnContext : ISpawnContext
@@ -79,9 +82,8 @@ public class SpawnManager : NetworkBehaviour
             Debug.LogError("Player prefab is not set in SpawnManager.");
             return null;
         }
-        
-        GameObject playerInstance = Instantiate(playerPrefab, spawnPosition, Quaternion.identity);
 
+        GameObject playerInstance = Instantiate(playerPrefab, spawnPosition, Quaternion.identity);
         NetworkObject networkObject = playerInstance.GetComponent<NetworkObject>();
         if (networkObject == null)
         {
@@ -90,19 +92,19 @@ public class SpawnManager : NetworkBehaviour
             return null;
         }
         networkObject.SpawnAsPlayerObject(clientId, true);
-        
-        if (networkObject.TryGetComponent<ISpawnable>(out var spawnable))
-        {
-            // 플레이어 임시 프리팹 생성
-            ISpawnPoint playerSpawnPoint = new SimpleSpawnPoint(spawnPosition, Quaternion.identity, SpawnFilter.None);
 
-            // PlayerRespawnPolicy는 현재 플레이어 캐릭터 자체에서 가져옴
-            // ISpawnPolicy는 현재 ISpawnable.OnSpawn에서 직접 사용되지 않음
-            ISpawnContext context = new DefaultSpawnContext(playerSpawnPoint, null, spawnable.GetRespawnPolicy());
-            spawnable.OnSpawn(context);
+        if (networkObject.TryGetComponent<ICombatant>(out var combatant))
+        {
+            if (combatant is ISpawnable spawnable)
+            {
+                ISpawnPoint playerSpawnPoint = new SimpleSpawnPoint(spawnPosition, Quaternion.identity, SpawnFilter.None);
+                ISpawnContext context = new DefaultSpawnContext(playerSpawnPoint, null, spawnable.GetRespawnPolicy());
+                spawnable.OnSpawn(context);
+            }
+            
+            RegisterSpawnable(combatant);
         }
 
-        SubscribeToDeathEvent(playerInstance);
         return networkObject;
     }
 
@@ -128,58 +130,146 @@ public class SpawnManager : NetworkBehaviour
             }
             networkObject.Spawn(true);
 
-            if (networkObject.TryGetComponent<ISpawnable>(out var spawnable))
+            if (networkObject.TryGetComponent<ICombatant>(out var combatant))
             {
-                ISpawnPoint enemySpawnPoint = new SimpleSpawnPoint(enemyInfo.spawnPoint.position, enemyInfo.spawnPoint.rotation, SpawnFilter.None);
-                ISpawnContext context = new DefaultSpawnContext(enemySpawnPoint, null, spawnable.GetRespawnPolicy());
-                spawnable.OnSpawn(context);
-            }
+                if (combatant is ISpawnable spawnable)
+                {
+                    ISpawnPoint enemySpawnPoint = new SimpleSpawnPoint(enemyInfo.spawnPoint.position, enemyInfo.spawnPoint.rotation, SpawnFilter.None);
+                    ISpawnContext context = new DefaultSpawnContext(enemySpawnPoint, null, spawnable.GetRespawnPolicy());
+                    spawnable.OnSpawn(context);
+                }
 
-            SubscribeToDeathEvent(enemyInstance);
+                RegisterSpawnable(combatant);
+                _initialPositions[combatant] = enemyInfo.spawnPoint.position;
+            }
         }
         _initialEnemiesSpawned = true;
     }
 
-    private void SubscribeToDeathEvent(GameObject instance)
+    private void RegisterSpawnable(ICombatant combatant)
     {
-        if(instance.TryGetComponent<ICombatant>(out var combatant))
+        var health = combatant.GetHealth();
+        if (health != null)
         {
-            combatant.GetHealth().OnDied += () => StartCoroutine(RespawnCoroutine(combatant));
+            health.OnDied += () => HandleDeath(combatant);
         }
+        else
+        {
+            Debug.LogError($"[SpawnManager] {((Component)combatant).name} has no IHealth component to register for death events.");
+        }
+    }
+
+    public void HandleDeath(ICombatant combatant)
+    {
+        if (!IsServer) return;
+
+        var combatantObj = combatant as UnityEngine.Object;
+        if (combatantObj == null)
+        {
+            Debug.LogError("[SpawnManager] HandleDeath: Dead combatant is null or destroyed.");
+            return;
+        }
+        Debug.Log($"[SpawnManager] {((Component)combatant).name}의 죽음을 처리합니다.");
+
+        var spawnable = combatant as ISpawnable;
+        if (spawnable == null)
+        {
+            Debug.LogError($"[SpawnManager] {((Component)combatant).name} is not ISpawnable. Cannot process death.");
+            return;
+        }
+
+        var respawnPolicy = spawnable.GetRespawnPolicy();
+        if (respawnPolicy != null && respawnPolicy.ShouldRespawn(spawnable))
+        {
+            StartCoroutine(RespawnCoroutine(combatant));
+        }
+        else
+        {
+            StartCoroutine(DespawnCoroutine(combatant));
+        }
+    }
+    
+    private IEnumerator DespawnCoroutine(ICombatant combatant)
+    {
+        Debug.Log($"[SpawnManager] {((Component)combatant).name}을(를) 디스폰합니다.");
+        
+        if (combatant is EnemyCharacter)
+        {
+            AIManager.Instance.UnregisterAI(combatant);
+        }
+        
+        if (combatant is Component component && component.TryGetComponent<NetworkObject>(out var netObj))
+        {
+            if (netObj.IsSpawned)
+            {
+                netObj.Despawn(true);
+            }
+        }
+        yield break;
     }
 
     private IEnumerator RespawnCoroutine(ICombatant combatant)
     {
-        var spawnableCombatant = combatant as ISpawnable;
-        var respawnPolicy = spawnableCombatant?.GetRespawnPolicy();
+        var spawnable = combatant as ISpawnable;
+        var respawnPolicy = spawnable.GetRespawnPolicy();
 
-        if (respawnPolicy == null || !respawnPolicy.ShouldRespawn(spawnableCombatant))
-        {
-            if (combatant is Component component && component.TryGetComponent<NetworkObject>(out var netObj))
-            {
-                if (netObj.IsSpawned) netObj.Despawn(true);
-            }
-            yield break;
-        }
-
-        TimeSpan delay = respawnPolicy.GetRespawnDelay(spawnableCombatant);
+        SetCharacterState(combatant, false);
+        
+        TimeSpan delay = respawnPolicy.GetRespawnDelay(spawnable);
         yield return new WaitForSeconds((float)delay.TotalSeconds);
 
-        if (spawnableCombatant != null)
+        ISpawnPoint point = respawnPolicy.SelectRespawnPoint(spawnable);
+        if (point == null)
         {
-            ISpawnPoint point = respawnPolicy.SelectRespawnPoint(spawnableCombatant);
-            if (point != null)
+            if (_initialPositions.TryGetValue(combatant, out var initialPos))
             {
-                if (combatant is Component component && component.TryGetComponent<IMovable>(out var movable))
-                {
-                    movable.Teleport(point.GetPosition());
-                }
-                
-                var health = combatant.GetHealth();
-                health.Heal(health.Max);
-
-                Debug.Log($"{((Component)combatant).name} has respawned at {point.GetPosition()}.");
+                point = new SimpleSpawnPoint(initialPos, Quaternion.identity, SpawnFilter.None);
             }
+            else if (playerSpawnPoints.Length > 0)
+            {
+                point = new SimpleSpawnPoint(playerSpawnPoints[0].position, playerSpawnPoints[0].rotation, SpawnFilter.Player);
+            } else
+            {
+                Debug.LogError("리스폰 지점을 찾을 수 없습니다!");
+                yield break;
+            }
+        }
+
+        if (combatant is Component component && component.TryGetComponent<IMovable>(out var movable))
+        {
+            movable.Teleport(point.GetPosition());
+        }
+        
+        var health = combatant.GetHealth();
+        health.Heal(health.Max);
+
+        SetCharacterState(combatant, true);
+
+        Debug.Log($"{((Component)combatant).name}이(가) {point.GetPosition()}에서 리스폰되었습니다.");
+    }
+    
+    private void SetCharacterState(ICombatant combatant, bool active)
+    {
+        if (combatant as Component == null) return;
+        
+        var component = combatant as Component;
+        if (component.TryGetComponent<Collider>(out var col)) col.enabled = active;
+        if (component.TryGetComponent<Renderer>(out var rend)) rend.enabled = active;
+        if (component.TryGetComponent<NavMeshAgent>(out var agent))
+        {
+            if (agent.isOnNavMesh)
+            {
+                agent.isStopped = !active;
+            }
+            agent.enabled = active;
+        }
+
+        if (combatant is EnemyCharacter)
+        {
+            if (active)
+                AIManager.Instance.SetEnemyAlive(combatant);
+            else
+                AIManager.Instance.SetEnemyDead(combatant);
         }
     }
 }


### PR DESCRIPTION
### 부활 싸이클 설계
> Manager클래스의 분리는 **“무엇을 결정하느냐”**가 Manager 분리 기준
> 보통 "상태 변환" 와 "생명 주기" 관리를 구분으로 한다
- Death는 두 단계로 나뉜다
  - 죽었다는 사실의 확정
  - 죽은 이후 어떻게 처리할지
- CombatManager (죽음 “확정”까지만 )
  - 데미지 계산
  - 체력 감소
  - 체력이 0 이하인지 판단
  - OnDied 이벤트 발생
- SpawnManager (죽음 “이후 처리” 전담, “죽었을 때 어떻게 할지”의 주인)
  -  OnDied 이벤트 구독
  - 리스폰 여부 판단
  - 리스폰 딜레이 관리
  - 재배치 / 제거
 
```
[CombatManager]
  ApplyDamage()
    ↓
[IHealth]
  Current -= damage
  if (Current <= 0)
      OnDied.Invoke()
    ↓
[SpawnManager]
  HandleDeath(ISpawnable)
    ↓
IRespawnPolicy.ShouldRespawn()
    ↓
Delay
    ↓
Respawn or Despawn
```